### PR TITLE
Feature/gaia 1599

### DIFF
--- a/src/main/kotlin/implicit/Implicit.kt
+++ b/src/main/kotlin/implicit/Implicit.kt
@@ -104,7 +104,7 @@ class Implicit(val namingStrategy: (TypeDescription) -> CharSequence) {
                             ImplicitViolations(acc.violations.plus(ex))
                         }
                     }
-            if(implicitViolations!=null && !implicitViolations.violations.isEmpty()){
+            if(!implicitViolations.violations.isEmpty()){
                 throw implicitViolations
             }
             return@Function instance

--- a/src/main/kotlin/implicit/annotation/validation/NotEmpty.kt
+++ b/src/main/kotlin/implicit/annotation/validation/NotEmpty.kt
@@ -1,0 +1,11 @@
+package implicit.annotation.validation
+
+import implicit.annotation.Implicit
+import implicit.annotation.Implicit.Type.VALIDATOR
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
+
+@Retention(RUNTIME)
+@Target(VALUE_PARAMETER)
+@Implicit(VALIDATOR)
+annotation class NotEmpty(val message:String = "")

--- a/src/main/kotlin/implicit/exception/ImplicitViolations.kt
+++ b/src/main/kotlin/implicit/exception/ImplicitViolations.kt
@@ -1,0 +1,3 @@
+package implicit.exception
+
+class ImplicitViolations(val violations: List<ImplicitValidationException>) : ImplicitException("Implicit validations were detected: " + violations.fold("") { acc, entry ->  acc.plus("[" + entry.message+ "]") })

--- a/src/main/kotlin/implicit/interceptor/generator/ValidationInterceptor.kt
+++ b/src/main/kotlin/implicit/interceptor/generator/ValidationInterceptor.kt
@@ -39,6 +39,7 @@ object ValidationInterceptor {
             is LowerThan -> return LowerThanValidator(annotation)
             is LowerEquals -> return LowerEqualsValidator(annotation)
             is NotBlank -> return NotBlankValidator(annotation)
+            is NotEmpty -> return NotEmptyValidator(annotation)
             is MaxLength -> return MaxLengthValidator(annotation)
             is MinLength -> return MinLengthValidator(annotation)
             is ContentNotNull -> return ContentNullValidator(annotation)

--- a/src/main/kotlin/implicit/interceptor/validator/NotEmptyValidator.kt
+++ b/src/main/kotlin/implicit/interceptor/validator/NotEmptyValidator.kt
@@ -1,10 +1,10 @@
 package implicit.interceptor.validator
 
-import implicit.annotation.validation.NotBlank
+import implicit.annotation.validation.NotEmpty
 import implicit.exception.ImplicitValidationException
 import java.lang.reflect.Method
 
-internal class NotBlankValidator(val annotation: NotBlank) : AbstractValidator() {
+internal class NotEmptyValidator(val annotation: NotEmpty) : AbstractValidator() {
 
     override fun validate(values: List<*>, method: Method) {
         for (value in values) {
@@ -12,7 +12,8 @@ internal class NotBlankValidator(val annotation: NotBlank) : AbstractValidator()
                 throwImplicitValidationException(method)
             }
             when (value) {
-                is String -> if(value.isBlank()) throwImplicitValidationException(method)
+                is Collection<*> -> if(value.isEmpty()) throwImplicitValidationException(method)
+                is String -> if(value.isEmpty()) throwImplicitValidationException(method)
 
             }
         }

--- a/src/test/kotlin/implicit/validation/validator/ImplicitViolationsTest.kt
+++ b/src/test/kotlin/implicit/validation/validator/ImplicitViolationsTest.kt
@@ -1,0 +1,87 @@
+package implicit.validation.validator
+
+import implicit.Implicit
+import implicit.annotation.validation.NotBlank
+import implicit.annotation.validation.NotEmpty
+import implicit.annotation.validation.NotNull
+import implicit.exception.ImplicitException
+import implicit.exception.ImplicitViolations
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.assertj.core.api.Assertions.assertThat
+
+class ImplicitViolationsTest {
+
+    @Test
+    fun happyPath() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+        val map= mapOf(
+                "notBlankName" to "name1",
+                "notNullName" to "name2",
+                "notEmptySet" to setOf("value")
+        )
+
+        val instance = factory.instantiate(ITest::class.java, map)
+
+        Assertions.assertTrue(instance.getNotBlankName()!!.isNotBlank())
+        Assertions.assertTrue(instance.getNotNullName()!=null)
+        Assertions.assertTrue(instance.getNotEmptySet()!!.size>0)
+    }
+
+    @Test
+    fun oneViolationDetected() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+        val map= mapOf(
+                "notBlankName" to "  ",
+                "notNullName" to "name2",
+                "notEmptySet" to setOf("value")
+        )
+        try{
+            factory.instantiate(ITest::class.java, map)
+        }catch (ex: ImplicitException ) {
+            when (ex) {
+                is ImplicitViolations -> {
+                    assertThat(ex.violations).hasSize(1)
+                    assertThat(ex.message).isEqualTo("Implicit validations were detected: [value of field 'setNotBlankName' is empty]")
+                }
+                else -> Assertions.fail("Implicit violation is expected")
+            }
+        }
+    }
+
+    @Test
+    fun multipleViolationsWhereDetected() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+        val map= mapOf(
+                "notBlankName" to "  ",
+                "notEmptySet" to setOf<String>()
+        )
+        try{
+            factory.instantiate(ITest::class.java, map)
+        }catch (ex: ImplicitException ) {
+            when (ex) {
+                is ImplicitViolations -> {
+                    assertThat(ex.violations).hasSize(3)
+                }
+                else -> Assertions.fail("Implicit violation is expected")
+            }
+        }
+    }
+
+
+
+
+    interface ITest {
+        fun setNotNullName(@NotNull notNullName: String?)
+        fun getNotNullName(): String?
+
+        fun setNotBlankName(@NotBlank notBlankName: String?)
+        fun getNotBlankName(): String?
+
+        fun setNotEmptySet(@NotEmpty notEmptySet: Set<Any>?)
+        fun getNotEmptySet(): Set<Any>?
+
+    }
+
+}

--- a/src/test/kotlin/implicit/validation/validator/NotBlankValidatorTest.kt
+++ b/src/test/kotlin/implicit/validation/validator/NotBlankValidatorTest.kt
@@ -1,0 +1,152 @@
+package implicit.validation.validator
+
+import implicit.Implicit
+import implicit.annotation.validation.NotBlank
+import implicit.annotation.validation.NotNull
+import implicit.exception.ImplicitException
+import implicit.exception.ImplicitValidationException
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class NotBlankValidatorTest {
+
+    @Test
+    fun callingSetterWithNullValue() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+        val supplier = factory.getSupplier(ITest::class.java)
+
+        val counter = AtomicInteger()
+
+        val instance = supplier.get()
+
+        try {
+            instance.setName(null)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        try {
+            instance.setName("test")
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNotNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun callingSetterWithEmptyStringValue() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+        val supplier = factory.getSupplier(ITest::class.java)
+
+        val counter = AtomicInteger()
+
+        val instance = supplier.get()
+
+        try {
+            instance.setName("")
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        try {
+            instance.setName("test")
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNotNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun callingSetterWithBlankValue() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+        val supplier = factory.getSupplier(ITest::class.java)
+
+        val counter = AtomicInteger()
+
+        val instance = supplier.get()
+
+        try {
+            instance.setName("     ")
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        try {
+            instance.setName("name")
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNotNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun instantiatingAnEntityWithAMapWhereValueIsNull() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+
+        val counter = AtomicInteger()
+        var instance = factory.getSupplier(ITest::class.java).get()
+        val map = mapOf<String, Any?>("name" to null)
+        try {
+            instance = factory.instantiate(ITest::class.java, map)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun instantiatingAnEntityWithAMapWhereValueIsEmptyString() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+
+        val counter = AtomicInteger()
+        var instance = factory.getSupplier(ITest::class.java).get()
+        val map = mapOf<String, Any?>("name" to "")
+        try {
+            instance = factory.instantiate(ITest::class.java, map)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun instantiatingAnEntityWithAMapWhereValueIsBlank() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+
+        val counter = AtomicInteger()
+        var instance = factory.getSupplier(ITest::class.java).get()
+        val map = mapOf<String, Any?>("name" to "    ")
+        try {
+            instance = factory.instantiate(ITest::class.java, map)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun instantiatingAnEntityWithAMapWhereKeyIsNotPresent() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+
+        val counter = AtomicInteger()
+        var instance = factory.getSupplier(ITest::class.java).get()
+        val map = mapOf<String, Any?>()
+        try {
+            instance = factory.instantiate(ITest::class.java, map)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    interface ITest {
+        fun setName(@NotBlank name: String?)
+        fun getName(): String?
+    }
+
+}

--- a/src/test/kotlin/implicit/validation/validator/NotEmptyValidatorTest.kt
+++ b/src/test/kotlin/implicit/validation/validator/NotEmptyValidatorTest.kt
@@ -1,0 +1,164 @@
+package implicit.validation.validator
+
+import implicit.Implicit
+import implicit.annotation.validation.NotEmpty
+import implicit.exception.ImplicitException
+import implicit.exception.ImplicitValidationException
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class NotEmptyValidatorTest {
+
+    @Test
+    fun callingStringSetterWithNullValue() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+        val supplier = factory.getSupplier(ITest::class.java)
+
+        val counter = AtomicInteger()
+
+        val instance = supplier.get()
+
+        try {
+            instance.setName(null)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        try {
+            instance.setName("test")
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNotNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun callingCollectionSetterWithNullValue() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+        val supplier = factory.getSupplier(ITest::class.java)
+
+        val counter = AtomicInteger()
+
+        val instance = supplier.get()
+
+        try {
+            instance.setList(null)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        try {
+            instance.setList(listOf("abc","def"))
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNotNull(instance.getList())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun callingStringSetterWithEmptyValue() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+        val supplier = factory.getSupplier(ITest::class.java)
+
+        val counter = AtomicInteger()
+
+        val instance = supplier.get()
+
+        try {
+            instance.setName("")
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        try {
+            instance.setName("test")
+            instance.setList(listOf("abc"))
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNotNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun callingCollectionSetterWithEmptyList() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+        val supplier = factory.getSupplier(ITest::class.java)
+
+        val counter = AtomicInteger()
+
+        val instance = supplier.get()
+
+        try {
+            instance.setList(listOf<Any>())
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        try {
+            instance.setName("test")
+            instance.setList(listOf("abc","def"))
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNotNull(instance.getList())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun instantiatingAnEntityWhichFieldInMapIsNull() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+
+        val counter = AtomicInteger()
+        var instance = factory.getSupplier(ITest::class.java).get()
+        val map = mapOf<String, Any?>("name" to null)
+        try {
+            instance = factory.instantiate(ITest::class.java, map)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun instantiatingAnEntityWhichFieldInMapIsNotPresent() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+
+        val counter = AtomicInteger()
+        var instance = factory.getSupplier(ITest::class.java).get()
+        val map = mapOf<String, Any?>()
+        try {
+            instance = factory.instantiate(ITest::class.java, map)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNull(instance.getName())
+        Assertions.assertNull(instance.getList())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun instantiatingAnEntityWhichFieldInMapIsEmpty() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+
+        val counter = AtomicInteger()
+        var instance = factory.getSupplier(ITest::class.java).get()
+        val map = mapOf<String, Any?>("name" to "")
+        try {
+            instance = factory.instantiate(ITest::class.java, map)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+
+    interface ITest {
+        fun setName(@NotEmpty name: String?)
+        fun getName(): String?
+        fun setList(@NotEmpty list: List<*>?)
+        fun getList(): List<*>?
+    }
+
+}

--- a/src/test/kotlin/implicit/validation/validator/NotEmptyValidatorTest.kt
+++ b/src/test/kotlin/implicit/validation/validator/NotEmptyValidatorTest.kt
@@ -43,16 +43,16 @@ class NotEmptyValidatorTest {
         val instance = supplier.get()
 
         try {
-            instance.setList(null)
+            instance.setCollectionList(null)
         } catch (ex: ImplicitException) {
             counter.incrementAndGet()
         }
         try {
-            instance.setList(listOf("abc","def"))
+            instance.setCollectionList(listOf("abc","def"))
         } catch (ex: ImplicitException) {
             counter.incrementAndGet()
         }
-        Assertions.assertNotNull(instance.getList())
+        Assertions.assertNotNull(instance.getCollectionList())
         Assertions.assertEquals(counter.get(), 1)
     }
 
@@ -72,7 +72,7 @@ class NotEmptyValidatorTest {
         }
         try {
             instance.setName("test")
-            instance.setList(listOf("abc"))
+            instance.setCollectionList(listOf("abc"))
         } catch (ex: ImplicitException) {
             counter.incrementAndGet()
         }
@@ -90,17 +90,18 @@ class NotEmptyValidatorTest {
         val instance = supplier.get()
 
         try {
-            instance.setList(listOf<Any>())
+            instance.setCollectionList(listOf<Any>())
         } catch (ex: ImplicitException) {
             counter.incrementAndGet()
         }
         try {
             instance.setName("test")
-            instance.setList(listOf("abc","def"))
+            instance.setCollectionList(listOf("abc","def"))
+
         } catch (ex: ImplicitException) {
             counter.incrementAndGet()
         }
-        Assertions.assertNotNull(instance.getList())
+        Assertions.assertNotNull(instance.getCollectionList())
         Assertions.assertEquals(counter.get(), 1)
     }
 
@@ -133,7 +134,7 @@ class NotEmptyValidatorTest {
             counter.incrementAndGet()
         }
         Assertions.assertNull(instance.getName())
-        Assertions.assertNull(instance.getList())
+        Assertions.assertNull(instance.getCollectionList())
         Assertions.assertEquals(counter.get(), 1)
     }
 
@@ -143,7 +144,7 @@ class NotEmptyValidatorTest {
 
         val counter = AtomicInteger()
         var instance = factory.getSupplier(ITest::class.java).get()
-        val map = mapOf<String, Any?>("name" to "")
+        val map = mapOf<String, Any?>("name" to "abc", "list" to mapOf<String,Any>())
         try {
             instance = factory.instantiate(ITest::class.java, map)
         } catch (ex: ImplicitException) {
@@ -157,8 +158,8 @@ class NotEmptyValidatorTest {
     interface ITest {
         fun setName(@NotEmpty name: String?)
         fun getName(): String?
-        fun setList(@NotEmpty list: List<*>?)
-        fun getList(): List<*>?
+        fun setCollectionList(@NotEmpty collectionList: List<Any>?)
+        fun getCollectionList(): List<Any>?
     }
 
 }

--- a/src/test/kotlin/implicit/validation/validator/NotNullValidatorTest.kt
+++ b/src/test/kotlin/implicit/validation/validator/NotNullValidatorTest.kt
@@ -3,6 +3,7 @@ package implicit.validation.validator
 import implicit.Implicit
 import implicit.annotation.validation.NotNull
 import implicit.exception.ImplicitException
+import implicit.exception.ImplicitValidationException
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.concurrent.atomic.AtomicInteger
@@ -10,7 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class NotNullValidatorTest {
 
     @Test
-    fun test() {
+    fun callingSetterWithNullValue() {
         val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
         val supplier = factory.getSupplier(ITest::class.java)
 
@@ -29,6 +30,38 @@ class NotNullValidatorTest {
             counter.incrementAndGet()
         }
         Assertions.assertNotNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun instantiatingAnEntityWithAMapWhereValueIsNull() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+
+        val counter = AtomicInteger()
+        var instance = factory.getSupplier(ITest::class.java).get()
+        val map = mapOf<String, Any?>("name" to null)
+        try {
+            instance = factory.instantiate(ITest::class.java, map)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNull(instance.getName())
+        Assertions.assertEquals(counter.get(), 1)
+    }
+
+    @Test
+    fun instantiatingAnEntityWithAMapWhereKeyIsNotPresent() {
+        val factory = Implicit { "${this.javaClass.name.toLowerCase()}.${it.simpleName}" }
+
+        val counter = AtomicInteger()
+        var instance = factory.getSupplier(ITest::class.java).get()
+        val map = mapOf<String, Any?>()
+        try {
+            instance = factory.instantiate(ITest::class.java, map)
+        } catch (ex: ImplicitException) {
+            counter.incrementAndGet()
+        }
+        Assertions.assertNull(instance.getName())
         Assertions.assertEquals(counter.get(), 1)
     }
 


### PR DESCRIPTION
PR for Implicit Extension:

1. NotEmpty validation added (for Strings and collections)
2. NotBlank validation improved --> Null is considered as Blank
3. When instantiating an instance from a map, all setters of the class are called (even if their fields are not present in the map). --> Old strategy might have better performance, but now all setters validations are executed. Specially the @NotNull validation of the setters).*

* Before initializing a field by calling a setter with null (if field is not present in map), we check if the getter is returning NULL. The reason for that is that the field might have been initialized via an ALIAS-setter.(in such case, we must not override the value)
