### PR TITLE
Feature/gaia 3355 add trim annotation for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,15 +175,31 @@ fun instantiateEntityA(){
     ))
 }
 ````
+
+## Trim
+
+The @Trim annotation can be used on methods that return a String value and is used to trim the content of the field
+
+````
+interface EntityA {
+   @Trim
+   fun getStringVal():String?
+}
+
+````
+
 ## Development
 
 ### Release
+
 Releases are triggered locally. Just a tag will be pushed and CI pipelines take care of the rest.
 
 #### Major
+
 Run `./gradlew final -x sendReleaseEmail -Prelease.scope=major` locally.
 
 #### Minor
+
 Run `./gradlew final -x sendReleaseEmail -Prelease.scope=minor` locally.
 
 #### Patch

--- a/src/main/kotlin/implicit/annotation/generator/Trim.kt
+++ b/src/main/kotlin/implicit/annotation/generator/Trim.kt
@@ -1,0 +1,12 @@
+package implicit.annotation.generator
+
+import implicit.annotation.Implicit
+import implicit.annotation.Implicit.Type.GENERATOR
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.ANNOTATION_CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+
+@Retention(RUNTIME)
+@Target(FUNCTION, ANNOTATION_CLASS)
+@Implicit(GENERATOR)
+annotation class Trim

--- a/src/main/kotlin/implicit/decorator/AddGetterSetterDecorator.kt
+++ b/src/main/kotlin/implicit/decorator/AddGetterSetterDecorator.kt
@@ -3,7 +3,9 @@ package implicit.decorator
 import implicit.annotation.Explicit
 import implicit.annotation.Implicit
 import implicit.annotation.generator.Default
+import implicit.annotation.generator.Trim
 import implicit.interceptor.generator.DefaultInterceptor
+import implicit.interceptor.generator.TrimInterceptor
 import implicit.interceptor.generator.ValidationInterceptor
 import net.bytebuddy.description.ByteCodeElement
 import net.bytebuddy.description.method.MethodDescription
@@ -46,23 +48,36 @@ class AddGetterSetterDecorator<T>(private val intf: Class<*>) : Function<Dynamic
         }
 
         return builder
-                .method(isDeclaredBy<ByteCodeElement>(typeMatcher)
-                        .and(not<MethodDescription>(isDefaultMethod<MethodDescription>()))
-                        .and(not<MethodDescription>(isAnnotatedWith(Explicit::class.java)))
-                        .and(not<MethodDescription>(isAnnotatedWith(Default::class.java)))
-                        .and(nameMatcher))
-                .intercept(FieldAccessor.ofBeanProperty())
-                .method(isDeclaredBy<ByteCodeElement>(typeMatcher)
-                        .and(annotationMatcher)
-                        .and(not<MethodDescription>(isAnnotatedWith(Default::class.java)))
-                        .and(nameMatcher))
-                .intercept(MethodDelegation.to(ValidationInterceptor)
-                        .andThen(FieldAccessor.ofBeanProperty()))
-                .method(                        isDeclaredBy<ByteCodeElement>(typeMatcher)
-                        .and(nameMatcher)
-                        .and(isAnnotatedWith(Default::class.java))
-                )
-                .intercept(MethodDelegation.to(DefaultInterceptor))
+            .method(
+                isDeclaredBy<ByteCodeElement>(typeMatcher)
+                    .and(not<MethodDescription>(isDefaultMethod<MethodDescription>()))
+                    .and(not<MethodDescription>(isAnnotatedWith(Explicit::class.java)))
+                    .and(not<MethodDescription>(isAnnotatedWith(Default::class.java)))
+                    .and(nameMatcher)
+            )
+            .intercept(FieldAccessor.ofBeanProperty())
+            .method(
+                isDeclaredBy<ByteCodeElement>(typeMatcher)
+                    .and(annotationMatcher)
+                    .and(not<MethodDescription>(isAnnotatedWith(Default::class.java)))
+                    .and(nameMatcher)
+            )
+            .intercept(
+                MethodDelegation.to(ValidationInterceptor)
+                    .andThen(FieldAccessor.ofBeanProperty())
+            )
+            .method(
+                isDeclaredBy<ByteCodeElement>(typeMatcher)
+                    .and(nameMatcher)
+                    .and(isAnnotatedWith(Default::class.java))
+            )
+            .intercept(MethodDelegation.to(DefaultInterceptor))
+            .method(
+                isDeclaredBy<ByteCodeElement>(typeMatcher)
+                    .and(nameMatcher)
+                    .and(isAnnotatedWith(Trim::class.java))
+            )
+            .intercept(MethodDelegation.to(TrimInterceptor))
     }
 
 }

--- a/src/main/kotlin/implicit/interceptor/generator/TrimInterceptor.kt
+++ b/src/main/kotlin/implicit/interceptor/generator/TrimInterceptor.kt
@@ -1,0 +1,41 @@
+package implicit.interceptor.generator
+
+import net.bytebuddy.implementation.bind.annotation.Origin
+import net.bytebuddy.implementation.bind.annotation.RuntimeType
+import net.bytebuddy.implementation.bind.annotation.This
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.util.concurrent.ConcurrentHashMap
+
+
+object TrimInterceptor {
+
+    private val fieldCache = ConcurrentHashMap<String, Field>()
+
+    @RuntimeType
+    fun intercept(@Origin method: Method, @This obj: Any): Any? {
+        fieldCache.computeIfAbsent(getKey(method)) { _ -> getField(method, obj) }
+        val fieldValue = fieldCache[getKey(method)]!!.get(obj)
+        return trim(fieldValue)
+    }
+
+
+    private fun getField(method: Method, obj: Any): Field {
+        val fieldName = method.name.substring(3).decapitalize()
+        val field = obj::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field
+    }
+
+    private fun trim(value: Any?): Any? {
+        return if (value == null) null else when {
+            value is String -> value.trim()
+            else -> value
+        }
+    }
+
+    private fun getKey(method: Method): String {
+        return method.declaringClass.name + "#" + method.name
+    }
+
+}

--- a/src/test/kotlin/implicit/generator/TrimTest.kt
+++ b/src/test/kotlin/implicit/generator/TrimTest.kt
@@ -1,0 +1,95 @@
+package implicit.generator
+
+import implicit.Implicit
+import implicit.annotation.generator.Default
+import implicit.annotation.generator.Trim
+import implicit.annotation.validation.NotNull
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class TrimTest {
+
+    @Test
+    fun `Set a value with empty spaces in front and after the string`() {
+        val factory = Implicit { "implicit.generator.default_.${it.simpleName}" }
+        val supplier = factory.getSupplier(Entity::class.java, true)
+
+        val pojo = supplier.get()
+        pojo.setAbc("test")
+        Assertions.assertEquals("test", pojo.getAbc())
+
+        pojo.setAbc("   test with space to trim   ")
+        Assertions.assertEquals("test with space to trim", pojo.getAbc())
+    }
+
+
+    @Test
+    fun `Test String fields with and without Trim annotations`() {
+        val factory = Implicit { "implicit.generator.default_.${it.simpleName}" }
+        val supplier = factory.getSupplier(Entity2::class.java)
+
+        val pojo = supplier.get()
+        pojo.setStringValWithoutTrimAnnotation(" This is a value with multiple empty characters at the beginning and at the end of the value    ")
+        pojo.setStringValWithTrimAnnotation("\t\n This is a value with multiple empty characters at the beginning and at the end of the value. But it will be trimmed  \r\n\n  ")
+        pojo.setLongVal(1L)
+
+
+        Assertions.assertEquals(
+            " This is a value with multiple empty characters at the beginning and at the end of the value    ",
+            pojo.getStringValWithoutTrimAnnotation()
+        )
+        Assertions.assertEquals(
+            "This is a value with multiple empty characters at the beginning and at the end of the value. But it will be trimmed",
+            pojo.getStringValWithTrimAnnotation()
+        )
+        Assertions.assertNull(pojo.getStringNullValWithTrimAnnotation())
+        Assertions.assertEquals(0, pojo.getIntVal())
+        Assertions.assertEquals(1.5f, pojo.getFloatVal())
+        Assertions.assertEquals(1.5, pojo.getDoubleVal())
+        Assertions.assertEquals(true, pojo.getBooleanVal())
+        Assertions.assertEquals(0, pojo.getShortVal())
+        Assertions.assertEquals(1, pojo.getLongVal())
+    }
+
+    interface Entity {
+        @Trim
+        fun getAbc(): String
+
+        fun setAbc(@NotNull id: String)
+    }
+
+    interface Entity2 {
+        fun getStringValWithoutTrimAnnotation(): String?
+        fun setStringValWithoutTrimAnnotation(@NotNull string: String)
+
+
+        @Trim
+        fun getStringValWithTrimAnnotation(): String?
+        fun setStringValWithTrimAnnotation(@NotNull string: String)
+
+        @Trim
+        fun getStringNullValWithTrimAnnotation(): String?
+
+        @Default("0")
+        fun getIntVal(): Int?
+
+        @Default("1.5")
+        fun getFloatVal(): Float?
+
+        @Default("1.5")
+        fun getDoubleVal(): Double?
+
+        @Default("true")
+        fun getBooleanVal(): Boolean?
+
+        @Default("0")
+        fun getShortVal(): Short?
+
+        @Trim
+        fun getLongVal(): Long?
+        fun setLongVal(longValue: Long)
+
+
+    }
+
+}

--- a/src/test/kotlin/implicit/generator/TrimTest.kt
+++ b/src/test/kotlin/implicit/generator/TrimTest.kt
@@ -11,7 +11,7 @@ class TrimTest {
 
     @Test
     fun `Set a value with empty spaces in front and after the string`() {
-        val factory = Implicit { "implicit.generator.default_.${it.simpleName}" }
+        val factory = Implicit { "implicit.generator.trim_.${it.simpleName}" }
         val supplier = factory.getSupplier(Entity::class.java, true)
 
         val pojo = supplier.get()
@@ -25,7 +25,7 @@ class TrimTest {
 
     @Test
     fun `Test String fields with and without Trim annotations`() {
-        val factory = Implicit { "implicit.generator.default_.${it.simpleName}" }
+        val factory = Implicit { "implicit.generator.trim_.${it.simpleName}" }
         val supplier = factory.getSupplier(Entity2::class.java)
 
         val pojo = supplier.get()


### PR DESCRIPTION
With annotation @Trim the value of the Getters is trimmed.

`
interface EntityA {
   @Trim
   fun getValue():String?
   fun setValue(value : String)
}
pojo.setValue("       \n Value     \r\n   ")
pojo.getValue() --> "Value"

`